### PR TITLE
Add: メニューに作成タブを追加、名称被り防止処理を追加

### DIFF
--- a/yUnoEngine/yUnoEngine/Application.cpp
+++ b/yUnoEngine/yUnoEngine/Application.cpp
@@ -1,7 +1,6 @@
 // ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
 // 　　ファイルのインクルード　　 //
 // ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
-#include "yUno_NetWorkManager.h"
 #include "Application.h"
 #include "WindowMenu.h"
 #include "yUno_MainManager.h"
@@ -238,31 +237,8 @@ LRESULT CALLBACK Application::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM
         // メニューバーがクリックされた場合
         case WM_COMMAND:
         {
-            switch (LOWORD(wParam))
-            {
-            // サーバーを開く
-            case WindowMenu::ID_OpenServer:
-                yUno_SystemManager::yUno_NetWorkManager::GetServer()->OpenServer();
-                break;
-            // サーバーを閉じる
-            case WindowMenu::ID_CloseServer:
-                yUno_SystemManager::yUno_NetWorkManager::GetServer()->CloseServer();
-                break;
-            // サーバーにログイン
-            case WindowMenu::ID_LoginServer:
-                yUno_SystemManager::yUno_NetWorkManager::GetServer()->LoginServer();
-                break;
-            // サーバーからログアウト
-            case WindowMenu::ID_LogoutServer:
-                yUno_SystemManager::yUno_NetWorkManager::GetServer()->LogoutServer();
-                break;
-            // メッセージを送る
-            case WindowMenu::ID_SendMessage:
-                yUno_SystemManager::yUno_NetWorkManager::GetServer()->SendData();
-                break;
-            default:
-                break;
-            }
+            // クリックされた内容の実行処理
+            WindowMenu::Run((LOWORD(wParam)));
             break;
         }
 

--- a/yUnoEngine/yUnoEngine/Assets/SampleScene.dat
+++ b/yUnoEngine/yUnoEngine/Assets/SampleScene.dat
@@ -1,31 +1,42 @@
 0 SpectatorCamera SpectatorCamera
 3
 PublicSystem::Transform
-0.000000, 0.989999, 0.000000
+0.000000, 0.000000, 0.000000
 0.000000, 0.000000, 0.000000
 1.000000, 1.000000, 1.000000
 PublicSystem::Shader
 PublicSystem::Camera
-1 Test Object1
+1 Test Cube
 5
 PublicSystem::Transform
-1.010000, 0.000000, 4.720016
+0.000000, 0.000000, 3.000000
 0.000000, 0.000000, 0.000000
 1.000000, 1.000000, 1.000000
 PublicSystem::Shader
 ModelRenderer
 BoxCollider
 PublicSystem::Material
-1 Test2 Text
-4
+1 Test Cube1
+5
 PublicSystem::Transform
 0.000000, 0.000000, 3.000000
 0.000000, 0.000000, 0.000000
 1.000000, 1.000000, 1.000000
 PublicSystem::Shader
+ModelRenderer
+BoxCollider
 PublicSystem::Material
-PublicSystem::Text
-1 Test2 Text2
+1 Test Cube2
+5
+PublicSystem::Transform
+0.000000, 0.000000, 3.000000
+0.000000, 0.000000, 0.000000
+1.000000, 1.000000, 1.000000
+PublicSystem::Shader
+ModelRenderer
+BoxCollider
+PublicSystem::Material
+2 Test2 Text
 4
 PublicSystem::Transform
 0.000000, 0.000000, 3.000000

--- a/yUnoEngine/yUnoEngine/GameObject.cpp
+++ b/yUnoEngine/yUnoEngine/GameObject.cpp
@@ -2,6 +2,7 @@
 // 　　ファイルのインクルード　　 //
 // ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
 #include "yUno_NetWorkManager.h"
+#include "yUno_GameObjectManager.h"
 #include "GameObject.h"
 #include "renderer.h"
 #include "Transform.h"
@@ -16,7 +17,7 @@ using namespace PublicSystem;
 
 GameObject::GameObject()
 {
-	// クリア
+	// オブジェクト名の初期化
 	ZeroMemory(m_name, sizeof(m_name));
 	// Transformコンポーネントを追加
 	transform = AddComponent <PublicSystem::Transform> ();
@@ -26,10 +27,39 @@ GameObject::GameObject()
 
 GameObject::GameObject(yUno_SceneManager* nowScene)
 {
+	// オブジェクト名の初期化
+	ZeroMemory(m_name, sizeof(m_name));
 	// Transformコンポーネントを追加
 	transform = AddComponent <PublicSystem::Transform>();
+	// Shaderコンポーネントを追加
+	AddComponent<PublicSystem::Shader>()->Load("Assets\\Shaders\\unlitTextureVS.cso", "Assets\\Shaders\\unlitTexturePS.cso");
 	// 現在シーンを代入する
 	m_myScene = nowScene;
+}
+
+void GameObject::SetName(const char* name)
+{
+	// オブジェクト名を初期化
+	ZeroMemory(m_name, sizeof(m_name));
+	
+	// オブジェクト名を付ける？
+	if (name)
+	{
+		// オブジェクト名が被っていないか確認し、
+		// 実際に付けるオブジェクト名を取得する
+		const char* newName = yUno_SystemManager::yUno_GameObjectManager::CheckObjectName(name);
+		memcpy_s(m_name, sizeof(m_name), newName, strlen(newName));
+	}
+}
+
+void GameObject::CopyName(const char* name)
+{
+	// オブジェクト名を初期化
+	ZeroMemory(m_name, sizeof(m_name));
+
+	// オブジェクト名を付ける？
+	if (name)
+		memcpy_s(m_name, sizeof(m_name), name, strlen(name));
 }
 
 void GameObject::InitBase()
@@ -55,24 +85,6 @@ void GameObject::UnInitBase()
 	UnInit();
 }
 
-
-Component* Test(Component* component)
-{
-	const char* componentType = typeid(*component).name();
-
-	if (strcmp(componentType, "class PublicSystem::Transform") == 0)
-	{
-		Transform* returnComponent = new Transform();
-		Transform* baseComponent = (Transform*)component;
-		returnComponent->Position = baseComponent->Position;
-		returnComponent->Rotation = baseComponent->Rotation;
-		returnComponent->Scale = baseComponent->Scale;
-		return returnComponent;
-	}
-	return 0;
-}
-
-Component* comp;
 void GameObject::UpdateBase()
 {
 	int index = 0;	// 要素数

--- a/yUnoEngine/yUnoEngine/GameObject.h
+++ b/yUnoEngine/yUnoEngine/GameObject.h
@@ -84,15 +84,15 @@ class GameObject
 		///	オブジェクト名	</returns>
 		const char* GetName() { return m_name; };
 		/// <summary>
-		///	オブジェクト名設定	</summary>
+		///	オブジェクト名を設定	</summary>
 		/// <param name="name">
 		/// 設定するオブジェクト名	</param>
-		void SetName(const char* name)
-		{
-			ZeroMemory(m_name, sizeof(m_name));
-			if (name)
-				memcpy_s(m_name, sizeof(m_name), name, strlen(name));
-		};
+		void SetName(const char* name);
+		/// <summary>
+		///	オブジェクト名をコピー	</summary>
+		/// <param name="name">
+		/// コピーするオブジェクト名	</param>
+		void CopyName(const char* name);
 
 		// オブジェクト単体に関わる処理
 		/// <summary>

--- a/yUnoEngine/yUnoEngine/SampleScene.cpp
+++ b/yUnoEngine/yUnoEngine/SampleScene.cpp
@@ -18,17 +18,13 @@ void SampleScene::Init()
     {
         AddSceneObject<SpectatorCamera>(0, "SpectatorCamera");
     }
-    if (GetSceneObject<Test>("Object1") == nullptr)
+    if (GetSceneObject<Test>("Cube") == nullptr)
     {
-        AddSceneObject<Test>(1, "Object1");
+        AddSceneObject<Test>(1, "Cube");
     }
     if (GetSceneObject<Test2>("Text") == nullptr)
     {
-        AddSceneObject<Test2>(1, "Text");
-    }
-    if(GetSceneObject<Test2>("Text2") == nullptr)
-    {
-        AddSceneObject<Test2>(1, "Text2");
+        AddSceneObject<Test2>(2, "Text");
     }
 }
 

--- a/yUnoEngine/yUnoEngine/Server.cpp
+++ b/yUnoEngine/yUnoEngine/Server.cpp
@@ -94,6 +94,8 @@ void Server::ReceiveThread()
 
 					// 通信成功
 					case MessageType::CommunicationSuccess:
+						// 通信の開始を設定
+						m_isCommunicationData = true;
 						// システム通知を表示
 						MessageBoxW(NULL, L"サーバーにログインしました", L"システム通知", MB_OK);
 						break;
@@ -345,14 +347,15 @@ void Server::LoginServer()
 		// 10進表記のIPアドレスを32ビットに変換（ネットワークバイトオーダー）
 		m_sendAddress.sin_addr.S_un.S_addr = inet_addr(str);
 
-		// 通信の開始を設定
-		m_isCommunicationData = true;
 		// 地位を設定
 		m_myServerRank = User;
 
-		// 受信スレッド生成
-		m_receiveThread = std::thread(&Server::ReceiveThread, this);
+		// スレッドが生成されていない？
+		if(!m_receiveThread.joinable())
+			// 受信スレッド生成
+			m_receiveThread = std::thread(&Server::ReceiveThread, this);
 
+		// 相手に通信開始通知を送る
 		m_sendData.message.header.type = MessageType::CommunicationStart;
 		SendMessageData(m_sendData);
 	}

--- a/yUnoEngine/yUnoEngine/SpectatorCamera.cpp
+++ b/yUnoEngine/yUnoEngine/SpectatorCamera.cpp
@@ -75,7 +75,7 @@ void SpectatorCamera::Update()
 			// メッセージタイプ
 			messageData.message.header.type = MessageType::ClickObject;
 			// オブジェクト
-			messageData.message.body.object.SetName(m_clickedObject->GetName());
+			messageData.message.body.object.CopyName(m_clickedObject->GetName());
 			
 			// メッセージを送る処理を実行
 			yUno_SystemManager::yUno_NetWorkManager::GetServer()->
@@ -93,7 +93,7 @@ void SpectatorCamera::Update()
 			// メッセージタイプ
 			messageData.message.header.type = MessageType::ClickObject;
 			// オブジェクト
-			messageData.message.body.object.SetName(m_clickedObject->GetName());
+			messageData.message.body.object.CopyName(m_clickedObject->GetName());
 
 			// メッセージを送る処理を実行
 			yUno_SystemManager::yUno_NetWorkManager::GetServer()->
@@ -111,7 +111,7 @@ void SpectatorCamera::Update()
 			// メッセージタイプ
 			messageData.message.header.type = MessageType::ClickObject;
 			// オブジェクト
-			messageData.message.body.object.SetName(nullptr);
+			messageData.message.body.object.CopyName(nullptr);
 
 			// メッセージを送る処理を実行
 			yUno_SystemManager::yUno_NetWorkManager::GetServer()->

--- a/yUnoEngine/yUnoEngine/WindowMenu.cpp
+++ b/yUnoEngine/yUnoEngine/WindowMenu.cpp
@@ -2,7 +2,10 @@
 // 　　ファイルのインクルード　　 //
 // ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
 #include "WindowMenu.h"
-#include "Application.h"
+
+#include "yUno_NetWorkManager.h"
+#include "SceneManager.h"
+#include "Test.h"
 
 void WindowMenu::Create()
 {
@@ -14,6 +17,20 @@ void WindowMenu::Create()
     MENUITEMINFO mii;
     memset(&mii, 0, sizeof(MENUITEMINFO));
     mii.cbSize = sizeof(MENUITEMINFO);
+
+    // ===== 作成タブ作成 ===== //
+    mii.fMask = MIIM_ID | MIIM_STRING | MIIM_SUBMENU;
+    mii.wID = ID_Create;
+    mii.dwTypeData = (LPWSTR)(L"作成");
+    hSubMenu = mii.hSubMenu = CreatePopupMenu();
+    InsertMenuItem(hMenu, ID_Create, TRUE, &mii);
+
+    mii.fMask = MIIM_ID | MIIM_STRING;
+    mii.wID = ID_CreateCube;
+    mii.dwTypeData = (LPWSTR)(L"Cube");
+    InsertMenuItem(hSubMenu, ID_CreateCube, FALSE, &mii);
+
+    // ===== サーバータブ作成 ===== //
     mii.fMask = MIIM_ID | MIIM_STRING | MIIM_SUBMENU;
     mii.wID = ID_Server;
     mii.dwTypeData = (LPWSTR)(L"サーバー");
@@ -48,4 +65,40 @@ void WindowMenu::Create()
 
     // ウィンドウにメニューを追加
     SetMenu(Application::GetWindow(), hMenu);
+}
+
+void WindowMenu::Run(WORD menuID)
+{
+    switch (menuID)
+    {
+        // ===== 作成タグの処理 ===== //
+        // Cube作成
+        case WindowMenu::ID_CreateCube:
+            PublicSystem::SceneManager::GetNowScene()->AddSceneObject<Test>(1, "Cube");
+            break;
+        // ===== サーバータグの処理 ===== //
+        // サーバーを開く
+        case WindowMenu::ID_OpenServer:
+            yUno_SystemManager::yUno_NetWorkManager::GetServer()->OpenServer();
+            break;
+        // サーバーを閉じる
+        case WindowMenu::ID_CloseServer:
+            yUno_SystemManager::yUno_NetWorkManager::GetServer()->CloseServer();
+            break;
+        // サーバーにログイン
+        case WindowMenu::ID_LoginServer:
+            yUno_SystemManager::yUno_NetWorkManager::GetServer()->LoginServer();
+            break;
+        // サーバーからログアウト
+        case WindowMenu::ID_LogoutServer:
+            yUno_SystemManager::yUno_NetWorkManager::GetServer()->LogoutServer();
+            break;
+        // メッセージを送る
+        case WindowMenu::ID_SendMessage:
+            yUno_SystemManager::yUno_NetWorkManager::GetServer()->SendData();
+            break;
+        // 上記以外
+        default:
+            break;
+    }
 }

--- a/yUnoEngine/yUnoEngine/WindowMenu.h
+++ b/yUnoEngine/yUnoEngine/WindowMenu.h
@@ -6,6 +6,8 @@
 * @date		2023.11.28
 */
 
+#include "Application.h"
+
 class WindowMenu
 {
 	public:
@@ -14,7 +16,12 @@ class WindowMenu
 		///	各メニューに割り振るID	</summary>
 		enum MenuID
 		{
-			ID_Server = 1,
+			// 作成タブ
+			ID_Create = 1,
+			ID_CreateCube,
+
+			// サーバータブ
+			ID_Server = 10,
 			ID_OpenServer,
 			ID_CloseServer,
 			ID_LoginServer,
@@ -26,5 +33,9 @@ class WindowMenu
 		/// <summary>
 		///	メニューを作成する	</summary>
 		static void Create();
+
+		/// <summary>
+		///	メニュー内容に従って、処理を実行	</summary>
+		static void Run(WORD menuID);
 };
 

--- a/yUnoEngine/yUnoEngine/yUnoEngine.vcxproj
+++ b/yUnoEngine/yUnoEngine/yUnoEngine.vcxproj
@@ -169,6 +169,7 @@
     <ClCompile Include="Vector3.cpp" />
     <ClCompile Include="WindowMenu.cpp" />
     <ClCompile Include="yUno_ComponentManager.cpp" />
+    <ClCompile Include="yUno_GameObjectManager.cpp" />
     <ClCompile Include="yUno_KeyInputManager.cpp" />
     <ClCompile Include="yUno_MainManager.cpp" />
     <ClCompile Include="yUno_MouseInputManager.cpp" />
@@ -213,6 +214,7 @@
     <ClInclude Include="Vector3.h" />
     <ClInclude Include="WindowMenu.h" />
     <ClInclude Include="yUno_ComponentManager.h" />
+    <ClInclude Include="yUno_GameObjectManager.h" />
     <ClInclude Include="yUno_KeyInputManager.h" />
     <ClInclude Include="yUno_MainManager.h" />
     <ClInclude Include="yUno_MouseInputManager.h" />

--- a/yUnoEngine/yUnoEngine/yUno_ComponentManager.cpp
+++ b/yUnoEngine/yUnoEngine/yUno_ComponentManager.cpp
@@ -48,7 +48,7 @@ void yUno_SystemManager::yUno_ComponentManager::SendMessageBasedOnType(Component
 			// メッセージタイプ
 			messageData.message.header.type = MessageType::UpdateComponent;
 			// オブジェクト
-			messageData.message.body.object.SetName(nowTransform.gameObject->GetName());
+			messageData.message.body.object.CopyName(nowTransform.gameObject->GetName());
 			// コンポーネントタイプ
 			strcpy_s(messageData.message.body.componentType,
 				sizeof(messageData.message.body.componentType),

--- a/yUnoEngine/yUnoEngine/yUno_GameObjectManager.cpp
+++ b/yUnoEngine/yUnoEngine/yUno_GameObjectManager.cpp
@@ -1,0 +1,106 @@
+// ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
+// 　　ファイルのインクルード　　 //
+// ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
+#include "yUno_GameObjectManager.h"
+
+
+// ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
+// 　　	　static変数の定義　　 　 //
+// ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
+std::list<yUno_SystemManager::yUno_GameObjectManager::ObjectNameData> yUno_SystemManager::yUno_GameObjectManager::m_objectNameList;
+std::list<yUno_SystemManager::yUno_GameObjectManager::ObjectNumberData> yUno_SystemManager::yUno_GameObjectManager::m_objectNumberList;
+
+
+void yUno_SystemManager::yUno_GameObjectManager::UnInit()
+{
+	// リストのクリア
+	m_objectNameList.clear();
+	m_objectNumberList.clear();
+}
+
+const char* yUno_SystemManager::yUno_GameObjectManager::CheckObjectName(const char* name)
+{
+	// 戻り値として扱う変数
+	char returnName[50];
+
+	// ===== オブジェクト名が被っていないか確認 ===== //
+	// オブジェクト名データ取得
+	for (auto& objNameData : m_objectNameList)
+	{
+		if (strcmp(objNameData.myName, name) == 0)
+		{
+			// 付与するオブジェクト番号取得
+			int number = GetObjectNumber(objNameData.baseName);
+			// オブジェクト名に番号を連結
+			sprintf_s(returnName, "%s%d", objNameData.baseName, number);
+
+			// ----- オブジェクト名データをリストに格納 ----- //
+			// インスタンス生成
+			ObjectNameData newObjNameData;
+			strcpy_s(newObjNameData.baseName, objNameData.baseName);	// 番号を付与する前の名前
+			strcpy_s(newObjNameData.myName, returnName);				// 現在の名前
+			newObjNameData.objectNameNumber = number;					// オブジェクト番号
+			// リストに格納
+			m_objectNameList.push_back(newObjNameData);
+
+			// オブジェクト名を戻り値として返す
+			return returnName;
+		}
+	}
+	///////////////////////////////////////////////
+	// ここまで来たら、オブジェクト名は被っていない
+	// =====　各データをリストに格納 ===== //
+	// ----- オブジェクト番号 ----- //
+	SetObjectNumber(name);
+	// ----- オブジェクト名 ----- //
+	// インスタンス生成
+	ObjectNameData newObjNameData;
+	strcpy_s(newObjNameData.baseName, name);	// 番号を付与する前の名前
+	strcpy_s(newObjNameData.myName, name);		// 現在の名前
+	newObjNameData.objectNameNumber = 0;		// オブジェクト番号
+	// リストに格納
+	m_objectNameList.push_back(newObjNameData);
+
+	// オブジェクト名を戻り値として返す
+	return name;
+}
+
+int yUno_SystemManager::yUno_GameObjectManager::GetObjectNumber(const char* name)
+{
+	// ===== オブジェクト番号取得 ===== //
+	// オブジェクト番号データ取得
+	for (auto& objNumberData : m_objectNumberList)
+	{
+		// オブジェクト名がデータと合致した？
+		if (strcmp(objNumberData.name, name) == 0)
+		{
+			// 空き番号がある？
+			if (!objNumberData.emptyNumber.empty())
+			{
+				// 空き番号を戻り値として返す
+				return objNumberData.emptyNumber[0];
+			}
+			// 空き番号がない
+			else
+			{
+				// 今回付与する番号を返す
+				return ++objNumberData.maxNumber;
+			}
+		}
+	}
+	///////////////////////////////////////////////////////////
+	// ここまで来たら、オブジェクト番号データが格納されていない
+	// ０を返す
+	return 0;
+}
+
+void yUno_SystemManager::yUno_GameObjectManager::SetObjectNumber(const char* name)
+{
+	// ===== 新規データの格納 ===== //
+	// インスタンス生成
+	ObjectNumberData objNumberData;
+	objNumberData.name = name;	// オブジェクト名
+	objNumberData.maxNumber = 0;// 最大値の番号
+	// リストに格納
+	m_objectNumberList.push_back(objNumberData);
+}

--- a/yUnoEngine/yUnoEngine/yUno_GameObjectManager.h
+++ b/yUnoEngine/yUnoEngine/yUno_GameObjectManager.h
@@ -1,0 +1,85 @@
+#pragma once
+/**
+* @file		yUno_GameObjectManager.h
+* @brief	yUno_GameObjectManagerクラスのヘッダーファイル
+* @author	Kojima, Kosei
+* @date		2023.12.08
+*/
+// ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
+// 　　ファイルのインクルード　　 //
+// ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
+#include <list>
+#include <vector>
+#include "GameObject.h"
+
+namespace yUno_SystemManager
+{
+	/// <summary>
+/// ゲームオブジェクトに関する機能をまとめたクラス	</summary>
+	class yUno_GameObjectManager
+	{
+	private:
+		// ----- structs / 構造体 ----- //
+		/// <summary>
+		/// オブジェクト名情報	</summary>
+		struct ObjectNameData
+		{
+			/// <summary>
+			///	自身のオブジェクト名	</summary>
+			char myName[30];
+			/// <summary>
+			///	元のオブジェクト名	</summary>
+			char baseName[30];
+			/// <summary>
+			///	オブジェクト名に付与する番号（名称被り防止）	</summary>
+			int objectNameNumber;
+		};
+		/// <summary>
+		/// オブジェクト番号情報	</summary>
+		struct ObjectNumberData
+		{
+			/// <summary>
+			///	オブジェクト名	</summary>
+			const char* name;
+			/// <summary>
+			///	空き番号	</summary>
+			std::vector<int> emptyNumber;
+			/// <summary>
+			///	番号の最大値	</summary>
+			int maxNumber;
+		};
+
+		// ----- variables / 変数 ----- //
+		/// <summary>
+		///	オブジェクト名リスト	</summary>
+		static std::list<ObjectNameData>m_objectNameList;
+		/// <summary>
+		///	オブジェクト番号リスト	</summary>
+		static std::list<ObjectNumberData>m_objectNumberList;
+
+	public:
+		// ----- functions / 関数 ----- //
+		static void UnInit();
+
+		/// <summary>
+		///	オブジェクト名が既に存在するかどうか確認	</summary>
+		/// <param name="name">
+		/// 確認するオブジェクト名	</param>
+		/// <returns>
+		///	実際に付けるオブジェクト名	</returns>
+		static const char* CheckObjectName(const char* name);
+		/// <summary>
+		///	オブジェクト名に付与する番号を取得	</summary>
+		/// <param name="name">
+		///	取得するオブジェクト名	</param>
+		/// <returns>
+		/// 付与する番号	</returns>
+		static int GetObjectNumber(const char* name);
+		/// <summary>
+		///	オブジェクト名に付与する番号を設定	</summary>
+		/// <param name="name">
+		/// 設定するオブジェクト名	</param>
+		static void SetObjectNumber(const char* name);
+	};
+}
+

--- a/yUnoEngine/yUnoEngine/yUno_SceneManager.cpp
+++ b/yUnoEngine/yUnoEngine/yUno_SceneManager.cpp
@@ -2,6 +2,7 @@
 // 　　ファイルのインクルード　　 //
 // ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
 #include "yUno_SceneManager.h"
+#include "yUno_GameObjectManager.h"
 #include "SampleScene.h"
 #include "GameObject.h"
 #include "BoxCollider.h"
@@ -231,8 +232,11 @@ void yUno_SceneManager::UnInitBase()
 			object->UnInitBase();	// 終了処理
 			delete object;			// 削除
 		}
-		objectList.clear();	//リストのクリア
+		//リストのクリア
+		objectList.clear();	
 	}
+	// マネージャーの終了処理
+	yUno_SystemManager::yUno_GameObjectManager::UnInit();
 	// 現在シーンの終了処理
 	m_loadedScene->UnInit();
 	delete m_loadedScene;

--- a/yUnoEngine/yUnoEngine/yUno_SceneManager.h
+++ b/yUnoEngine/yUnoEngine/yUno_SceneManager.h
@@ -10,6 +10,7 @@
 // ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
 #include <list>
 #include <array>
+#include <vector>
 #include "GameObject.h"
 
 /// <summary>
@@ -17,6 +18,8 @@
 class yUno_SceneManager
 {
 	private :
+		
+
 		// ----- variables / 変数 ----- //
 		/// <summary>
 		///	シーン名	</summary>
@@ -30,7 +33,7 @@ class yUno_SceneManager
 		///	シーン情報をロード	</summary>
 		/// <param name="loadSceneName">
 		///	ロードするシーン名	</param>
-		void LoadSceneData(const char* loadSceneName);
+		void LoadSceneData(const char* loadSceneName);		
 
 	protected:
 		// ----- variables / 変数 ----- //


### PR DESCRIPTION
【内容】
・オブジェクトをアプリケーション起動中に
　追加したかったので作成タブを追加した。
　作成タブ→Cubeをクリックすると、Cubeオブジェクトが作成される
・オブジェクトを作成した際、オブジェクト名が被らないように、名称被り防止の処理を作成
　名称が被っていた場合、後ろに番号を付与する(例)Object → Object1, Object1 → Object2