### PR TITLE
Add: 起動するシーン情報を扱うクラス"LaunchSceneInformation"を追加

### DIFF
--- a/yUnoEngine/yUnoEngine/EditScene.cpp
+++ b/yUnoEngine/yUnoEngine/EditScene.cpp
@@ -32,7 +32,6 @@ void yUnoEngine::EditScene::Init()
 	else
 	{
 		// シーン編集に使うデータを作成
-		strcpy_s(m_sceneEditorData.buildSceneName, "SampleScene");
 		m_sceneEditorData.transformComponent = *m_spectatorCamera->transform;
 		m_sceneEditorData.cameraComponent = *m_spectatorCamera->GetComponent<Camera>();
 	}
@@ -49,7 +48,6 @@ void yUnoEngine::EditScene::UnInit()
 {
 	// ===== セーブ処理 ===== //
 	// シーン編集に使うデータを作成
-	strcpy_s(m_sceneEditorData.buildSceneName, SceneManager::GetNowScene()->GetSceneName());
 	m_sceneEditorData.transformComponent = *m_spectatorCamera->transform;
 	m_sceneEditorData.cameraComponent = *m_spectatorCamera->GetComponent<Camera>();
 
@@ -102,13 +100,4 @@ void yUnoEngine::EditScene::Update()
 
 	// シーンの基本的な更新処理を実行
 	SceneBase::Update();
-}
-
-const char* yUnoEngine::EditScene::GetBuildSceneName()
-{
-	// 開くシーンが存在しない？
-	if(m_sceneEditorData.buildSceneName == nullptr)
-		return "SampleScene";	// サンプルシーン名を返す
-	// 開くシーンがあれば、そのシーン名を返す
-	return m_sceneEditorData.buildSceneName;
 }

--- a/yUnoEngine/yUnoEngine/EditScene.h
+++ b/yUnoEngine/yUnoEngine/EditScene.h
@@ -35,10 +35,6 @@ namespace yUnoEngine
 				///	編集時に使用するカメラのコンポーネント情報	</summary>
 				Transform transformComponent;	// トランスフォーム
 				Camera cameraComponent;			// カメラ
-
-				/// <summary>
-				///	開くシーン名	</summary>
-				char buildSceneName[30];
 			};
 			
 			// ----- variables / 変数 ----- //
@@ -63,12 +59,6 @@ namespace yUnoEngine
 			void Init() override;
 			void UnInit() override;
 			void Update() override;
-
-			/// <summary>
-			///	編集開始時に開くシーン名を取得	</summary>
-			/// <returns>
-			///	開くシーン名	</returns>
-			const char* GetBuildSceneName();
 	};
 };
 

--- a/yUnoEngine/yUnoEngine/LaunchSceneInformation.cpp
+++ b/yUnoEngine/yUnoEngine/LaunchSceneInformation.cpp
@@ -1,0 +1,52 @@
+#include "LaunchSceneInformation.h"
+#include "SceneManager.h"
+#include <stdio.h>
+#include <Windows.h>
+
+
+yUnoEngine::Information::LaunchSceneInformation::LaunchSceneInformation()
+{
+	ZeroMemory(m_launchSceneName, sizeof(m_launchSceneName));
+}
+
+void yUnoEngine::Information::LaunchSceneInformation::Load()
+{
+	// シーンファイルを開く
+	FILE* file;
+	fopen_s(&file, "Assets\\LaunchScene.info", "rb");
+
+	// 開くことが出来た？
+	if (file)
+	{
+		// ファイル読み取り
+		fread(m_launchSceneName, sizeof(m_launchSceneName), 1, file);
+		fclose(file);
+	}
+}
+
+void yUnoEngine::Information::LaunchSceneInformation::Save()
+{
+	// 情報の取得
+	strcpy_s(m_launchSceneName, SceneManager::GetNowScene()->GetSceneName());
+
+	// シーンファイルを開く
+	FILE* file;
+	fopen_s(&file, "Assets\\LaunchScene.info", "wb");
+
+	// 開くことが出来た？
+	if (file)
+	{
+		// ファイル書き込み
+		fwrite(m_launchSceneName, sizeof(m_launchSceneName), 1, file);
+		fclose(file);
+	}
+}
+
+const char* yUnoEngine::Information::LaunchSceneInformation::GetLaunchSceneName()
+{
+	// 開くシーンが存在しない？
+	if (strlen(m_launchSceneName) == 0)
+		return nullptr;			// nullptrを返す
+	// 開くシーンがあれば、そのシーン名を返す
+	return m_launchSceneName;
+}

--- a/yUnoEngine/yUnoEngine/LaunchSceneInformation.h
+++ b/yUnoEngine/yUnoEngine/LaunchSceneInformation.h
@@ -1,0 +1,46 @@
+#pragma once
+/**
+* @file		LaunchSceneInformation.h
+* @brief	LaunchSceneInformationクラスのヘッダーファイル
+* @author	Kojima, Kosei
+* @date		2024.01.06
+*/
+// ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
+// 　　ファイルのインクルード　　 //
+// ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
+
+namespace yUnoEngine
+{
+	namespace Information
+	{
+		/// <summary>
+		/// 起動するシーン情報</summary>
+		class LaunchSceneInformation
+		{
+			private:
+				// ----- variables / 変数 ----- //
+				/// <summary>
+				///	起動するシーン名	</summary>
+				char m_launchSceneName[30];
+
+			public:
+				// ----- functions / 関数 ----- //
+				/// <summary>
+				///	コンストラクタ	</summary>
+				LaunchSceneInformation();
+				/// <summary>
+				///	情報のロード	</summary>
+				void Load();
+				/// <summary>
+				///	情報のセーブ	</summary>
+				void Save();
+
+				/// <summary>
+				///	起動するシーン名を取得	</summary>
+				/// <returns>
+				///	シーンがあれば起動するシーン名、無ければnullptr	</returns>
+				const char* GetLaunchSceneName();
+		};
+	}
+}
+

--- a/yUnoEngine/yUnoEngine/WindowMenu.cpp
+++ b/yUnoEngine/yUnoEngine/WindowMenu.cpp
@@ -2,6 +2,7 @@
 // 　　ファイルのインクルード　　 //
 // ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
 #include "yUno_NetWorkManager.h"
+#include "yUno_SceneManager.h"
 
 #include "WindowMenu.h"
 #include "SceneManager.h"
@@ -17,6 +18,19 @@ void WindowMenu::Create()
     MENUITEMINFO mii;
     memset(&mii, 0, sizeof(MENUITEMINFO));
     mii.cbSize = sizeof(MENUITEMINFO);
+
+    // ===== ファイルタブ作成 ===== //
+    mii.fMask = MIIM_ID | MIIM_STRING | MIIM_SUBMENU;
+    mii.fMask = MIIM_ID | MIIM_STRING | MIIM_SUBMENU;
+    mii.wID = ID_Create;
+    mii.dwTypeData = (LPWSTR)(L"ファイル");
+    hSubMenu = mii.hSubMenu = CreatePopupMenu();
+    InsertMenuItem(hMenu, ID_File, TRUE, &mii);
+
+    mii.fMask = MIIM_ID | MIIM_STRING;
+    mii.wID = ID_CreateCube;
+    mii.dwTypeData = (LPWSTR)(L"新規シーン");
+    InsertMenuItem(hSubMenu, ID_NewScene, FALSE, &mii);
 
     // ===== 作成タブ作成 ===== //
     mii.fMask = MIIM_ID | MIIM_STRING | MIIM_SUBMENU;
@@ -71,7 +85,15 @@ void WindowMenu::Run(WORD menuID)
 {
     switch (menuID)
     {
-        // ===== 作成タグの処理 ===== //
+        // ===== ファイルタブの処理 ===== //
+        //------------//
+        // 新規シーン //
+        case WindowMenu::ID_NewScene:
+        {
+
+        }
+
+        // ===== 作成タブの処理 ===== //
         //----------//
         // Cube作成 //
         case WindowMenu::ID_CreateCube:
@@ -87,7 +109,7 @@ void WindowMenu::Run(WORD menuID)
             yUno_SystemManager::yUno_NetWorkManager::GetServer()->SendMessageData(messageData);
             break;
         }
-        // ===== サーバータグの処理 ===== //
+        // ===== サーバータブの処理 ===== //
         //----------------//
         // サーバーを開く //
         case WindowMenu::ID_OpenServer:

--- a/yUnoEngine/yUnoEngine/WindowMenu.h
+++ b/yUnoEngine/yUnoEngine/WindowMenu.h
@@ -16,12 +16,16 @@ class WindowMenu
 		///	各メニューに割り振るID	</summary>
 		enum MenuID
 		{
+			// ファイルタブ
+			ID_File,
+			ID_NewScene,
+
 			// 作成タブ
-			ID_Create = 1,
+			ID_Create = 10,
 			ID_CreateCube,
 
 			// サーバータブ
-			ID_Server = 10,
+			ID_Server = 20,
 			ID_OpenServer,
 			ID_CloseServer,
 			ID_LoginServer,

--- a/yUnoEngine/yUnoEngine/yUnoEngine.vcxproj
+++ b/yUnoEngine/yUnoEngine/yUnoEngine.vcxproj
@@ -148,6 +148,7 @@
     <ClCompile Include="FileReader.cpp" />
     <ClCompile Include="GameObject.cpp" />
     <ClCompile Include="KeyInput.cpp" />
+    <ClCompile Include="LaunchSceneInformation.cpp" />
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="Manipulator.cpp" />
     <ClCompile Include="Manipulator_MoveY.cpp" />
@@ -200,6 +201,7 @@
     <ClInclude Include="GameObject.h" />
     <ClInclude Include="KeyInput.h" />
     <ClInclude Include="InputPartsName.h" />
+    <ClInclude Include="LaunchSceneInformation.h" />
     <ClInclude Include="Manipulator.h" />
     <ClInclude Include="Manipulator_MoveY.h" />
     <ClInclude Include="Manipulator_MoveZ.h" />

--- a/yUnoEngine/yUnoEngine/yUnoEngine.vcxproj.filters
+++ b/yUnoEngine/yUnoEngine/yUnoEngine.vcxproj.filters
@@ -219,6 +219,18 @@
     <ClCompile Include="yUno_CollisionManager.cpp">
       <Filter>ソース ファイル</Filter>
     </ClCompile>
+    <ClCompile Include="Manipulator.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
+    <ClCompile Include="Manipulator_MoveY.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
+    <ClCompile Include="Manipulator_MoveZ.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
+    <ClCompile Include="LaunchSceneInformation.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Component.h">
@@ -360,6 +372,18 @@
       <Filter>ヘッダー ファイル</Filter>
     </ClInclude>
     <ClInclude Include="yUno_CollisionManager.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
+    <ClInclude Include="Manipulator.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
+    <ClInclude Include="Manipulator_MoveY.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
+    <ClInclude Include="Manipulator_MoveZ.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
+    <ClInclude Include="LaunchSceneInformation.h">
       <Filter>ヘッダー ファイル</Filter>
     </ClInclude>
   </ItemGroup>

--- a/yUnoEngine/yUnoEngine/yUno_GameObjectManager.h
+++ b/yUnoEngine/yUnoEngine/yUno_GameObjectManager.h
@@ -58,7 +58,8 @@ namespace yUno_SystemManager
 			static void SetObjectNameData(ObjectNameData objNameData);
 			/// <summary>
 			/// オブジェクト名情報を削除	/// </summary>
-			/// <param name="name"></param>
+			/// <param name="name">
+			///	削除するオブジェクト名	</param>
 			static void DeleteObjectNameData(const char* name);
 		
 		private:

--- a/yUnoEngine/yUnoEngine/yUno_SceneManager.h
+++ b/yUnoEngine/yUnoEngine/yUno_SceneManager.h
@@ -9,6 +9,11 @@
 // 　　ファイルのインクルード　　 //
 // ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
 #include "SceneBase.h"
+#include "LaunchSceneInformation.h"
+
+#include <string>
+#include <unordered_map>
+
 
 /// <summary>
 /// シーンに関する機能をまとめたクラス	</summary>
@@ -19,6 +24,12 @@ class yUno_SceneManager
 		/// <summary>
 		///	エディット用シーン	</summary>
 		static SceneBase* m_editScene;
+		/// <summary>
+		///	シーン一覧	</summary>
+		static std::unordered_map<std::string, SceneBase*> m_scenePool;
+		/// <summary>
+		///	起動するシーン情報	</summary>
+		static yUnoEngine::Information::LaunchSceneInformation m_launchSceneInfo;
 
 		// ----- functions / 関数 ----- //
 		/// <summary>
@@ -67,6 +78,11 @@ class yUno_SceneManager
 		///	現在シーンの描画処理	</summary>
 		static void DrawScene();
 
+		/// <summary>
+		///	新規シーンを作成	</summary>
+		/// <param name="sceneName">
+		///	新規シーン名	</param>
+		static void CreateNewScene(const char* sceneName);
 #if _DEBUG
 		static SceneBase* GetEditScene() { return m_editScene; };
 #endif


### PR DESCRIPTION
【内容】
前までは起動するシーン情報は”EditScene”クラス内で扱っていたが、
ビルドした際に”EditScene”を生成しない関係上、不具合が発生するので、情報を別クラスで扱うことにした。