### PR TITLE
Update: エディット時にテキストをキー入力で変更できる機能を追加

### DIFF
--- a/yUnoEngine/yUnoEngine/Text.cpp
+++ b/yUnoEngine/yUnoEngine/Text.cpp
@@ -5,11 +5,11 @@ void PublicSystem::Text::AddText(const char* addText)
     // テキスト長を取得
     int textLength = strlen(this->text);
     // 値をコピー
-    memcpy(dummyText, GetComponent<Text>()->text, textLength);
+    memcpy(dummyText, this->text, textLength);
 
     // 追加する文字列長だけループ
     int addTextNum = 0;
-    for (int i = textLength; i < textLength + strlen(addText); i++)
+    for (int i = textLength; i <= textLength + strlen(addText); i++)
     {
         dummyText[i] = addText[addTextNum];
         addTextNum++;
@@ -26,5 +26,19 @@ void PublicSystem::Text::ChangeText(const char* changeText)
     // 値をコピー
     memcpy(dummyText, changeText, textLength);
     // 追加するテキストを代入
+    this->text = dummyText;
+}
+
+void PublicSystem::Text::DeleteText()
+{
+    // テキスト長を取得
+    int textLength = strlen(this->text);
+    
+    // テキストが入っている？
+    if(textLength >= 1)
+        // 末尾の文字を削除
+        strncpy_s(dummyText, dummyText, textLength - 1);
+    
+    // 削除後のテキストを代入
     this->text = dummyText;
 }

--- a/yUnoEngine/yUnoEngine/Text.h
+++ b/yUnoEngine/yUnoEngine/Text.h
@@ -9,7 +9,7 @@
 // 　　ファイルのインクルード　　 //
 // ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
 #include "TextRenderer.h"
-
+#include <iostream>
 
 namespace PublicSystem
 {
@@ -24,7 +24,14 @@ namespace PublicSystem
 			/// <param name="addText">
 			/// 追加するテキスト	</param>
 			void AddText(const char* addText);
+			/// <summary>
+			///	現在のテキストを変更する	</summary>
+			/// <param name="changeText">
+			///	変更するテキスト	</param>
 			void ChangeText(const char* changeText);
+			/// <summary>
+			///	現在のテキストの末尾を削除	</summary>
+			void DeleteText();
 	};
 }
 

--- a/yUnoEngine/yUnoEngine/TextRenderer.cpp
+++ b/yUnoEngine/yUnoEngine/TextRenderer.cpp
@@ -53,6 +53,7 @@ void TextRenderer::Update()
 	}
 
 	// 現在表示されているテキストを保存する
+	ZeroMemory(m_lateText, sizeof(m_lateText));
 	memcpy(m_lateText, text, strlen(text));
 }
 

--- a/yUnoEngine/yUnoEngine/yUno_KeyInputManager.cpp
+++ b/yUnoEngine/yUnoEngine/yUno_KeyInputManager.cpp
@@ -2,6 +2,7 @@
 // 　　   ファイルのインクルード        //
 // ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
 #include "yUno_KeyInputManager.h"
+#include "yUno_TextRendererManager.h"
 #include "KeyInput.h"
 #include "ShortCutKey.h"
 #include "Time.h"
@@ -76,8 +77,12 @@ void yUno_SystemManager::yUno_KeyInputManager::SetKeyDown(int key)
 		// 要素数を増やす
 		m_downStateKeyInfo.keyIndex++;
 		
+#if _DEBUG
 		// ショートカットコマンドの実行
 		yUno_SystemParts::ShortCutKey::Run(key);
+		// テキストの入力処理
+		yUno_TextRendererManager::Input(key);
+#endif
 	}
 }
 

--- a/yUnoEngine/yUnoEngine/yUno_TextRendererManager.h
+++ b/yUnoEngine/yUnoEngine/yUno_TextRendererManager.h
@@ -90,6 +90,13 @@ namespace yUno_SystemManager
 			/// <param name = "_addFont">
 			/// 今回追加するフォント	</param>
 			static void SetFont(HFONT addFont);
+
+			//** 入力系 **//
+			/// <summary>
+			///	テキストに文字入力を行う	</summary>
+			/// <param name="key">
+			///	入力されたキーコード	</param>
+			static void Input(int keyCode);
 	};
 }
 


### PR DESCRIPTION
【内容】
エディット時にテキストをクリック後、キー入力を行うことで入力した文字がテキストに追加される

テキストクリック
　　↓
文字キー（英語＋数字）入力　→　文字追加
スペースキー　　　　　　　　　→　空白追加
バックスペースキー　　　　　　　→　文字削除