### PR TITLE
Update: テキストの大文字小文字判定の追加

### DIFF
--- a/yUnoEngine/yUnoEngine/Test2.h
+++ b/yUnoEngine/yUnoEngine/Test2.h
@@ -17,8 +17,6 @@ class Test2 : public GameObject
 	public:
 		void Init()
 		{
-			//AddComponent<ModelRenderer>()->Load("Assets\\Models\\yUno_TemplateBox.obj");
-			//AddComponent<BoxCollider>();
 			GetComponent<PublicSystem::Shader>()->Load("Assets\\Shaders\\unlitTextureVS.cso", "Assets\\Shaders\\unlitTexturePS.cso");
 			Material mat;
 			AddComponent<Material>();
@@ -26,28 +24,9 @@ class Test2 : public GameObject
 			transform->position.x = 0.0f;
 			transform->position.z = 3.0f;
 			Text* textComponent = AddComponent<Text>();
-			textComponent->text = "Hello";
+			textComponent->text = "Input text...";
 			textComponent->fontSize = Vector2(20, 30);
 
-		}
-
-		void Update()
-		{
-			Text* textComponent = GetComponent<Text>();
-
-			if(KeyInput::GetKeyDownTrigger(P))
-			{
-				textComponent->text = "bcc";
-			}
-			else if (KeyInput::GetKeyUpTrigger(P))
-			{
-				textComponent->text = "Hello";
-			}
-
-			if (KeyInput::GetKeyDownTrigger(I))
-			{
-				textComponent->AddText("World");
-			}
 		}
 };
 

--- a/yUnoEngine/yUnoEngine/yUno_TextRendererManager.cpp
+++ b/yUnoEngine/yUnoEngine/yUno_TextRendererManager.cpp
@@ -265,6 +265,7 @@ wchar_t toLower(wchar_t ch) {
 	return towlower(ch);
 }
 
+#include "KeyInput.h"
 void yUno_SystemManager::yUno_TextRendererManager::Input(int keyCode)
 {
 	// 入力可能状態のテキストが存在する？
@@ -283,8 +284,10 @@ void yUno_SystemManager::yUno_TextRendererManager::Input(int keyCode)
 		// 文字として扱えるキーが入力された
 		if (result == 1)
 		{
-			// 大文字を小文字に変換
-			std::transform(typeChar, typeChar + result, typeChar, toLower);
+			// シフトキーが押されていない？
+			if(KeyInput::GetKeyUp(LeftShift) && KeyInput::GetKeyUp(RightShift))
+				// 大文字を小文字に変換
+				std::transform(typeChar, typeChar + result, typeChar, toLower);
 
 			// バッファサイズの取得
 			int bufferSize = WideCharToMultiByte(CP_UTF8, 0, std::wstring(typeChar).c_str(), -1, nullptr, 0, nullptr, nullptr);


### PR DESCRIPTION
【内容】
エディと画面でテキスト入力時、シフトキーの押下状態で大文字と小文字を分けるようにした
分け方は一般的なものと同じで、シフトキーを押しているときは大文字、それ以外は小文字