### PR TITLE
Fix: カメラを回転させた際、クリック判定が正しく動作しない問題を修正

### DIFF
--- a/C+lan/C+lan/Application.cpp
+++ b/C+lan/C+lan/Application.cpp
@@ -204,14 +204,7 @@ LRESULT CALLBACK Ctlan::PrivateSystem::Application::WndProc(HWND hWnd, UINT msg,
         case WM_KEYDOWN:
         {
             // 押されているキーを取得
-            WORD KeyID = HIWORD(lParam);
-
-            // 求めた値が大きすぎる
-            if (KeyID > 10000)
-                KeyID -= 49152;  // 欲しい値に修正する
-            // 求めた値がまだ大きすぎる
-            if (KeyID > 10000)
-                KeyID -= 32768;  // 欲しい値にさらに修正する
+            WORD KeyID = LOWORD(wParam);
 
             // 押されたキーを保存する関数を実行
             Ctlan::PrivateSystem::SystemManager::SystemKeyInputManager::SetKeyDown(KeyID);
@@ -222,14 +215,7 @@ LRESULT CALLBACK Ctlan::PrivateSystem::Application::WndProc(HWND hWnd, UINT msg,
         case WM_KEYUP:
         {
             // 押されているキーを取得
-            WORD KeyID = HIWORD(lParam);
-
-            // 求めた値が大きすぎる
-            if (KeyID > 10000)
-                KeyID -= 49152;  // 欲しい値に修正する
-            // 求めた値がまだ大きすぎる
-            if (KeyID > 10000)
-                KeyID -= 32768;  // 欲しい値にさらに修正する
+            WORD KeyID = LOWORD(wParam);
 
             // 離されたキーを保存する関数を実行
             Ctlan::PrivateSystem:: SystemManager::SystemKeyInputManager::SetKeyUp(KeyID);

--- a/C+lan/C+lan/EditScene.cpp
+++ b/C+lan/C+lan/EditScene.cpp
@@ -122,7 +122,10 @@ void Ctlan::EngineScene::EditScene::Update()
 	{
 		isDemoPlay = isDemoPlay ? false : true;	// デモプレイ状態を切り替える
 	}
+	// デモプレイ中ならオブジェクトの更新は行わない
+	if (isDemoPlay)return;
 
+	// ===== エディットシーンオブジェクトの更新処理 ===== //
 	// 各スレッド内のオブジェクトリスト取得
 	for (auto& objectList : m_sceneObjectList)
 	{
@@ -138,6 +141,9 @@ void Ctlan::EngineScene::EditScene::Update()
 
 void Ctlan::EngineScene::EditScene::Draw()
 {
+	// デモプレイ中ならオブジェクトの描画は行わない
+	if (isDemoPlay)return;
+
 	// 各スレッド内のオブジェクトリスト取得
 	for (auto& objectList : m_sceneObjectList)
 	{

--- a/C+lan/C+lan/InputPartsName.h
+++ b/C+lan/C+lan/InputPartsName.h
@@ -6,6 +6,7 @@
 * @date		2023.11.05
 */
 
+
 namespace Ctlan
 {
 	namespace PublicSystem
@@ -19,235 +20,268 @@ namespace Ctlan
 			// ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝//
 			/// <summary>
 			/// Aキー	</summary>
-			A = 30,
+			A = 65,
 			/// <summary>
 			/// Bキー	</summary>
-			B = 48,
+			B = 66,
 			/// <summary>
 			/// Cキー	</summary>
-			C = 46,
+			C = 67,
 			/// <summary>
 			/// Dキー	</summary>
-			D = 32,
+			D = 68,
 			/// <summary>
 			/// Eキー	</summary>
-			E = 18,
+			E = 69,
 			/// <summary>
 			/// Fキー	</summary>
-			F = 33,
+			F = 70,
 			/// <summary>
 			/// Gキー	</summary>
-			G = 34,
+			G = 71,
 			/// <summary>
 			/// Hキー	</summary>
-			H = 35,
+			H = 72,
 			/// <summary>
 			/// Iキー	</summary>
-			I = 23,
+			I = 73,
 			/// <summary>
 			/// Jキー	</summary>
-			J = 36,
+			J = 74,
 			/// <summary>
 			/// Kキー	</summary>
-			K = 37,
+			K = 75,
 			/// <summary>
 			/// Lキー	</summary>
-			L = 38,
+			L = 76,
 			/// <summary>
 			/// Mキー	</summary>
-			M = 50,
+			M = 77,
 			/// <summary>
 			/// Nキー	</summary>
-			N = 49,
+			N = 78,
 			/// <summary>
 			/// Oキー	</summary>
-			O = 24,
+			O = 79,
 			/// <summary>
 			/// Pキー	</summary>
-			P = 25,
+			P = 80,
 			/// <summary>
 			/// Qキー	</summary>
-			Q = 16,
+			Q = 81,
 			/// <summary>
 			/// Rキー	</summary>
-			R = 19,
+			R = 82,
 			/// <summary>
 			/// Sキー	</summary>
-			S = 31,
+			S = 83,
 			/// <summary>
 			/// Tキー	</summary>
-			T = 20,
+			T = 84,
 			/// <summary>
 			/// Uキー	</summary>
-			U = 22,
+			U = 85,
 			/// <summary>
 			/// Vキー	</summary>
-			V = 47,
+			V = 86,
 			/// <summary>
 			/// Wキー	</summary>
-			W = 17,
+			W = 87,
 			/// <summary>
 			/// Xキー	</summary>
-			X = 45,
+			X = 88,
 			/// <summary>
 			/// Yキー	</summary>
-			Y = 21,
+			Y = 89,
 			/// <summary>
 			/// Zキー	</summary>
-			Z = 44,
+			Z = 90,
 			// ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝//
 			//  NumericKey / テンキー・数字キー  //
 			// ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝//
 			/// <summary>
 			/// 1キー	</summary>
-			Number1 = 2,
+			Number1 = 49,
 			/// <summary>
 			/// 2キー	</summary>
-			Number2 = 3,
+			Number2 = 50,
 			/// <summary>
 			/// 3キー	</summary>
-			Number3 = 4,
+			Number3 = 51,
 			/// <summary>
 			/// 4キー	</summary>
-			Number4 = 5,
+			Number4 = 52,
 			/// <summary>
 			/// 5キー	</summary>
-			Number5 = 6,
+			Number5 = 53,
 			/// <summary>
 			/// 6キー	</summary>
-			Number6 = 7,
+			Number6 = 54,
 			/// <summary>
 			/// 7キー	</summary>
-			Number7 = 8,
+			Number7 = 55,
 			/// <summary>
 			/// 8キー	</summary>
-			Number8 = 9,
+			Number8 = 56,
 			/// <summary>
 			/// 9キー	</summary>
-			Number9 = 10,
+			Number9 = 57,
 			/// <summary>
 			/// 0キー	</summary>
-			Number0 = 11,
+			Number0 = 48,
+			// ＝＝＝＝＝＝＝＝＝＝＝ //
+			//  SymbolKey / 記号キー  //
+			// ＝＝＝＝＝＝＝＝＝＝＝ //
+			/// <summary>
+			///	セミコロン	</summary>
+			Semicolon = 187,
+
 			// ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
 			//  FunctionKey / ファンクションキー  //
 			// ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
 			/// <summary>
 			/// F1キー	</summary>
-			F1 = 59,
+			F1 = 112,
 			/// <summary>
 			/// F2キー	</summary>
-			F2 = 60,
+			F2 = 113,
 			/// <summary>
 			/// F3キー	</summary>
-			F3 = 61,
+			F3 = 114,
 			/// <summary>
 			/// F4キー	</summary>
-			F4 = 62,
+			F4 = 115,
 			/// <summary>
 			/// F5キー	</summary>
-			F5 = 63,
+			F5 = 116,
 			/// <summary>
 			/// F6キー	</summary>
-			F6 = 64,
+			F6 = 117,
 			/// <summary>
 			/// F7キー	</summary>
-			F7 = 65,
+			F7 = 118,
 			/// <summary>
 			/// F8キー	</summary>
-			F8 = 66,
+			F8 = 119,
 			/// <summary>
 			/// F9キー	</summary>
-			F9 = 67,
+			F9 = 120,
+			/// F10キー	</summary>
+			F10 = 121,
 			/// <summary>
 			/// F11キー	</summary>
-			F11 = 87,
+			F11 = 122,
 			/// <summary>
 			/// F12キー	</summary>
-			F12 = 88,
+			F12 = 123,
+			/// F13キー	</summary>
+			F13 = 124,
+			/// F14キー	</summary>
+			F14 = 125,
+			/// F15キー	</summary>
+			F15 = 126,
+			/// F16キー	</summary>
+			F16 = 127,
+			/// F17キー	</summary>
+			F17 = 128,
+			/// F18キー	</summary>
+			F18 = 129,
+			/// F19キー	</summary>
+			F19 = 130,
+			/// F20キー	</summary>
+			F20 = 131,
+			/// F21キー	</summary>
+			F21 = 132,
+			/// F22キー	</summary>
+			F22 = 133,
+			/// F23キー	</summary>
+			F23 = 134,
+			/// F24キー	</summary>
+			F24 = 135,
 			// ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝//
 			//		OtherKey / その他のキー	     //
 			// ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝//
 			/// <summary>
 			///	エスケープキー／Esc	</summary>
-			Escape = 1,
+			Escape = 27,
 			/// <summary>
 			/// バックスペースキー／BackSpace	</summary>
-			BackSpace = 14,
+			BackSpace = 8,
 			/// <summary>
 			/// タブキー／Tab	</summary>
-			Tab = 15,
+			Tab = 9,
 			/// <summary>
 			///	エンターキー／Enter	</summary>
-			Enter = 28,
+			Enter = 13,
 			/// <summary>
-			///	「左側」にあるシフトキー／Shift	</summary>
-			LeftShift = 42,
+			///	左側にあるシフトキー／Shift	</summary>
+			LeftShift = 16,
 			/// <summary>
-			///	「右側」にあるシフトキー／Shift	</summary>
-			RightShift = 310,
+			///	右側にあるシフトキー／Shift	</summary>
+			RightShift = 16,
 			/// <summary>
-			///	「左側」にあるコントロールキー／Ctrl	</summary>
-			LeftControl = 29,
+			///	左側にあるコントロールキー／Ctrl	</summary>
+			LeftControl = 17,
 			/// <summary>
-			///	「右側」にあるコントロールキー／Ctrl	</summary>
-			RightControl = 285,
+			///	右側にあるコントロールキー／Ctrl	</summary>
+			RightControl = 17,
 			/// <summary>
 			/// 半角/全角漢字キー	</summary>
-			Hankaku = 41,
+			Hankaku = 229,
 			/// <summary>
 			///	半角/全角漢字キー	</summary>
-			Zenkaku = 41,
+			Zenkaku = 229,
 			/// <summary>
 			/// スペースキー	</summary>
-			Space = 57,
+			Space = 32,
 			/// <summary>
 			///	変換キー	</summary>
-			Henkann = 121,
+			Henkann = 28,
 			/// <summary>
 			/// 無変換キー	</summary>
-			MuHenkann = 123,
+			MuHenkann = 229,
 			/// <summary>
 			///	CapsLockキー	</summary>
 			CapsLock = 58,
 			/// <summary>
 			///	Homeキー	</summary>
-			Home = 327,
+			Home = 36,
 			/// <summary>
 			///	PageUpキー	</summary>
-			PageUp = 329,
+			PageUp = 33,
 			/// <summary>
 			///	PageDownキー	</summary>
-			PageDown = 337,
+			PageDown = 34,
 			/// <summary>
 			/// Endキー	</summary>
-			End = 335,
+			End = 35,
 			/// <summary>
 			///	上矢印キー／↑	</summary>
-			UpArrow = 328,
+			UpArrow = 38,
 			/// <summary>
 			///	左矢印キー／←	</summary>
-			LeftArrow = 331,
+			LeftArrow = 37,
 			/// <summary>
 			/// 下矢印キー／↓</summary>
-			DownArrow = 336,
+			DownArrow = 40,
 			/// <summary>
 			///	右矢印キー／→	</summary>
-			RightArrow = 333,
+			RightArrow = 39,
 			/// <summary>
 			/// Deleteキー	</summary>
-			Delete = 339,
+			Delete = 46,
 			/// <summary>
 			///	Windowsキー	</summary>
-			Windows = 347,
+			Windows = 91,
 			/// <summary>
 			/// カタカナひらがなローマ字キー</summary>
-			Katakana = 16496,
+			Katakana = 229,
 			/// <summary>
 			/// カタカナひらがなローマ字キー</summary>
-			Hiragana = 16496,
+			Hiragana = 229,
 			/// <summary>
 			/// カタカナひらがなローマ字キー</summary>
-			Romaji = 16496,
+			Romaji = 229,
 		};
 
 

--- a/C+lan/C+lan/SceneBase.cpp
+++ b/C+lan/C+lan/SceneBase.cpp
@@ -1,8 +1,10 @@
 #include "SystemNetWorkManager.h"
 #include "SystemGameObjectManager.h"
 #include "SystemCollisionManager.h"
+#include "SystemSceneManager.h"
 
 #include "SceneBase.h"
+#include "EditScene.h"
 #include "Camera.h"
 #include "Message.h"
 
@@ -102,9 +104,14 @@ void Ctlan::PrivateSystem::SceneBase::Draw()
 		{
 // デバッグ時の処理
 #if _DEBUG
-			// カメラコンポーネントを持っている？
-			if (object->GetComponent<Camera>())
-				continue;	// 次のオブジェクトに遷移
+			// デモプレイ中ではない？
+			if(!dynamic_cast<EngineScene::EditScene*>(SystemManager::SystemSceneManager::GetEditScene())->IsDemoPlay())
+			{
+				// カメラコンポーネントを持っている？
+				if (object->GetComponent<Camera>())
+					continue;	// 次のオブジェクトに遷移
+			}
+
 #endif
 // 通常の処理
 			// アクティブ状態？

--- a/C+lan/C+lan/Server.cpp
+++ b/C+lan/C+lan/Server.cpp
@@ -57,36 +57,40 @@ void Ctlan::PrivateSystem::Server::ReceiveThread()
 				{
 					// ----- 通信相手をリストに格納 ----- //
 					// 通信相手の情報を保存する
-					CommunicationUserData comUser;
-					comUser.userRank = (ServerRank)m_sendData.message.header.userRank;
-					int userNo = 1;
-					bool success = true;
+					CommunicationUserData comUser;						// 通信ユーザー情報
+					comUser.userRank =									// ユーザーランク
+						(ServerRank)m_sendData.message.header.userRank;
+					int userNo = 1;										// ユーザー番号(１番から確認)
+					bool success = true;								// ユーザー番号が決まったかどうか
+
+					// ユーザー番号が決まるまでループ
 					do
 					{
 						success = true;
-						for (const CommunicationUserData data : m_comUserList)
+						// 現在ログインしているユーザー分ループ
+						for (const CommunicationUserData& data : m_comUserList)
 						{
+							// ユーザー番号が他ユーザーと被った？
 							if (data.userNo == userNo)
 							{
-								userNo++;
-								success = false;
+								userNo++;		// 番号を加算
+								success = false;// 再度ループするように変更
 								break;
 							}
 						}
 					} while (!success);
 
+					// 値代入
 					m_sendData.message.header.userRank = User;
 					m_sendData.message.header.userNo = userNo;
 					comUser.userNo = userNo;
 					comUser.address = m_sendAddress;
-
 					// リストに格納
 					m_comUserList.push_back(comUser);
 
 					// ----- 相手に通信成功を伝える ----- //
 					m_sendData.message.header.type = MessageType::CommunicationSuccess;
 					SendMessageData(m_sendData);
-					m_myServerNo = 0;
 					break;
 				}
 				//----------//
@@ -192,7 +196,6 @@ void Ctlan::PrivateSystem::Server::ReceiveThread()
 							break;
 						}
 					}
-
 					// まだロックされていないオブジェクト？
 					if (!isRocked)
 					{
@@ -203,7 +206,8 @@ void Ctlan::PrivateSystem::Server::ReceiveThread()
 						rockObjectData.rockUserNo = m_receiveData.message.header.userNo;
 						m_rockObjectList.push_back(rockObjectData);
 					}
-					SendMessageOtherUser();
+
+					SendMessageOtherUser();	// 他ユーザーにメッセージ送信
 					break;
 				}
 				//------------------//

--- a/C+lan/C+lan/SpectatorCamera.cpp
+++ b/C+lan/C+lan/SpectatorCamera.cpp
@@ -23,51 +23,73 @@ void Ctlan::EngineObject::SpectatorCamera::Init()
 void Ctlan::EngineObject::SpectatorCamera::Update()
 {
 	// ===== カメラの操作 ===== //
-	// ----- マウスでカメラ移動 ----- //
-	// ホイールボタンが押されている？
-	if (MouseInput::GetMouseDown(ScrollWheelButton))
+	// オブジェクトを選択していない？（オブジェクトを選択していない場合、カメラの操作が行える）
+	if (m_clickedObject == nullptr)
 	{
-		Vector2 moveAmount = MouseInput::GetCursorMoveAmount();
-		Vector3 addVec = Vector3(moveAmount.x, moveAmount.y, 0.0f);
-		transform->position += addVec.Rotate(transform->rotation) * 0.01f;
-	}
-	else
-	{
-		// ----- キー入力でカメラ移動 ----- //
-	// 上矢印キーが押されている？
-		if (KeyInput::GetKeyDown(UpArrow))
+		// ----- マウスでカメラ移動 ----- //
+		// ホイールボタンが押されている？
+		if (MouseInput::GetMouseDown(ScrollWheelButton))
 		{
-			Vector3 addVec = Vector3(0.0f, 1.0f, 0.0f);
+			Vector2 moveAmount = MouseInput::GetCursorMoveAmount();
+			Vector3 addVec = Vector3(moveAmount.x, moveAmount.y, 0.0f);
 			transform->position += addVec.Rotate(transform->rotation) * 0.01f;
 		}
-		// 左矢印キーが押されている？
-		if (KeyInput::GetKeyDown(LeftArrow))
+		// ホイールボタンが回転された？
+		else if (MouseInput::GetWheelRotation())
 		{
-			Vector3 addVec = Vector3(-1.0f, 0.0f, 0.0f);
-			transform->position += addVec.Rotate(transform->rotation) * 0.01f;
+			// 前方回転された？
+			if (MouseInput::GetWheelRotationForward())
+			{
+				// 前方に移動
+				Vector3 addVec = Vector3(0.0f, 0.0f, 10.0f);
+				transform->position += addVec.Rotate(transform->rotation) * 0.01f;
+			}
+			// 後方回転された
+			else
+			{
+				// 後方に移動
+				Vector3 addVec = Vector3(0.0f, 0.0f, -10.0f);
+				transform->position += addVec.Rotate(transform->rotation) * 0.01f;
+			}
 		}
-		// 下矢印キーが押されている？
-		if (KeyInput::GetKeyDown(DownArrow))
+		else
 		{
-			Vector3 addVec = Vector3(0.0f, -1.0f, 0.0f);
-			transform->position += addVec.Rotate(transform->rotation) * 0.01f;
+			// ----- キー入力でカメラ移動 ----- //
+			// 上矢印キーが押されている？
+			if (KeyInput::GetKeyDown(UpArrow))
+			{
+				Vector3 addVec = Vector3(0.0f, 1.0f, 0.0f);
+				transform->position += addVec.Rotate(transform->rotation) * 0.01f;
+			}
+			// 左矢印キーが押されている？
+			if (KeyInput::GetKeyDown(LeftArrow))
+			{
+				Vector3 addVec = Vector3(-1.0f, 0.0f, 0.0f);
+				transform->position += addVec.Rotate(transform->rotation) * 0.01f;
+			}
+			// 下矢印キーが押されている？
+			if (KeyInput::GetKeyDown(DownArrow))
+			{
+				Vector3 addVec = Vector3(0.0f, -1.0f, 0.0f);
+				transform->position += addVec.Rotate(transform->rotation) * 0.01f;
+			}
+			// 右矢印キーが押されている？
+			if (KeyInput::GetKeyDown(RightArrow))
+			{
+				Vector3 addVec = Vector3(1.0f, 0.0f, 0.0f);
+				transform->position += addVec.Rotate(transform->rotation) * 0.01f;
+			}
 		}
-		// 右矢印キーが押されている？
-		if (KeyInput::GetKeyDown(RightArrow))
-		{
-			Vector3 addVec = Vector3(1.0f, 0.0f, 0.0f);
-			transform->position += addVec.Rotate(transform->rotation) * 0.01f;
-		}
-	}
 
-	// ----- カメラ回転 ----- //
-	// 右クリックが押されている？
-	if (MouseInput::GetMouseDown(RightButton))
-	{
-		// カーソルの移動量に合わせてカメラを回転
-		Vector2 moveAmount = PublicSystem::MouseInput::GetCursorMoveAmount();
-		transform->rotation.x -= moveAmount.y * 0.01f * PublicSystem::Time::DeltaTime;
-		transform->rotation.y += moveAmount.x * 0.01f * PublicSystem::Time::DeltaTime;
+		// ----- カメラ回転 ----- //
+		// 右クリックが押されている？
+		if (MouseInput::GetMouseDown(RightButton))
+		{
+			// カーソルの移動量に合わせてカメラを回転
+			Vector2 moveAmount = PublicSystem::MouseInput::GetCursorMoveAmount();
+			transform->rotation.x -= moveAmount.y * 0.01f * PublicSystem::Time::DeltaTime;
+			transform->rotation.y += moveAmount.x * 0.01f * PublicSystem::Time::DeltaTime;
+		}
 	}
 
 	// ===== クリックしたオブジェクトを取得 ===== //

--- a/C+lan/C+lan/SystemSceneManager.cpp
+++ b/C+lan/C+lan/SystemSceneManager.cpp
@@ -354,13 +354,6 @@ void Ctlan::PrivateSystem::SystemManager::SystemSceneManager::InitScene()
 #endif	
 	// 初期シーンのロード
 	LoadScene();
-	//m_loadedScene->AddSceneObject<Meteor>(1, "Meteor");
-	//m_loadedScene->AddSceneObject<Meteor>(1, "Meteor");
-	//m_loadedScene->AddSceneObject<Meteor>(1, "Meteor");
-	//m_loadedScene->AddSceneObject<Meteor>(1, "Meteor");
-	//m_loadedScene->AddSceneObject<Meteor>(1, "Meteor");
-	//Text* textCom = m_loadedScene->AddSceneObject<Test2>(3, "Text")->GetComponent<Text>();
-	//textCom->text = "Press Any Key";
 }
 
 void Ctlan::PrivateSystem::SystemManager::SystemSceneManager::UninitScene()

--- a/C+lan/C+lan/SystemSceneManager.h
+++ b/C+lan/C+lan/SystemSceneManager.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <unordered_map>
 
+
 namespace Ctlan
 {
 	namespace PrivateSystem

--- a/C+lan/C+lan/TextRenderer.h
+++ b/C+lan/C+lan/TextRenderer.h
@@ -71,7 +71,7 @@ namespace Ctlan
 				/// <param name="text"> 
 				///	描画する文字	</param>
 				/// <param name="textNum">
-				/// 何文字目か	</param>
+				/// 何文字目か	</param>ee
 				/// <returns>
 				/// 作成したテキスト情報	</returns>
 				TextInfo CreateTextWithoutVertexBuffer(char text, int textNum);
@@ -80,7 +80,7 @@ namespace Ctlan
 				//  ----- variables / 変数 ----- //
 				/// <summary>
 				/// 表示するテキスト </summary>
-				const char* text;
+				const char* text = "";
 				/// <summary>
 				///	テキストの内容変更などで使う仮テキスト	</summary>
 				char dummyText[101] = {};

--- a/C+lan/C+lan/Vector3.cpp
+++ b/C+lan/C+lan/Vector3.cpp
@@ -26,6 +26,19 @@ Ctlan::PublicSystem::Vector3 Ctlan::PublicSystem::Vector3::Rotate(const Vector3 
     return *this;
 }
 
+void Ctlan::PublicSystem::Vector3::Normalize()
+{
+    // ベクトルの長さを求める
+    float length = sqrtf(x * x + y * y + z * z);
+    // 長さが0でない場合、各値を長さで割る
+    if (length != 0.0f)
+    {
+        x /= length;
+        y /= length;
+        z /= length;
+    }
+}
+
 Ctlan::PublicSystem::Vector3 Ctlan::PublicSystem::Vector3::operator=(const Vector3& vec)
 {
     x = vec.x;

--- a/C+lan/C+lan/Vector3.h
+++ b/C+lan/C+lan/Vector3.h
@@ -64,6 +64,10 @@ namespace Ctlan
 				///	どれだけ回転させるかを示す値	</param>
 				Vector3 Rotate(const Vector3 &rotation);
 
+				/// <summary>
+				///	ベクトルを正規化する	</summary>
+				void Normalize();
+
 				// ----- 演算子のオーバーロード群 ----- //
 				//**  assignment / 代入  **//
 				/// <summary>


### PR DESCRIPTION
【内容】
カメラが回転している状態でクリックした場合、クリック判定が起きる位置がずれている問題が発生。
＞最遠描画地点の計算にカメラの座標が含まれていたのが原因
【解決方法】
カメラの座標を含めずに最遠描画地点の計算（原点で計算）
最遠描画地点を回転後、カメラの座標に加えるようにした。