### PR TITLE
Fix: サーバーを開いたユーザーのメッセージがログイン中のユーザー全員に送信されていなかったので修正

### DIFF
--- a/C+lan/C+lan/Application.cpp
+++ b/C+lan/C+lan/Application.cpp
@@ -181,6 +181,8 @@ LRESULT CALLBACK Ctlan::PrivateSystem::Application::WndProc(HWND hWnd, UINT msg,
     {
         // ウィンドウを閉じるアクションが発生した場合
         case WM_CLOSE:
+// デバッグ時
+#if _DEBUG
             // 終了確認で「OK」が押された？
             if (MessageBox(NULL, L"終了しますか？", L"終了確認", MB_OKCANCEL) == IDOK)
             {
@@ -192,7 +194,7 @@ LRESULT CALLBACK Ctlan::PrivateSystem::Application::WndProc(HWND hWnd, UINT msg,
                 }
                 // ウィンドウを閉じる
                 DestroyWindow(hWnd);
-            }
+            }  
             // 終了確認で「CANCEL」が押された
             else
             {
@@ -200,7 +202,11 @@ LRESULT CALLBACK Ctlan::PrivateSystem::Application::WndProc(HWND hWnd, UINT msg,
                 msg = WM_NULL;
             }
             break;
-
+// リリース時
+#else
+            // ウィンドウを閉じる
+            DestroyWindow(hWnd);
+#endif
         // ウィンドウが閉じた場合
         case WM_DESTROY:
             PostQuitMessage(0);

--- a/C+lan/C+lan/C+lan.h
+++ b/C+lan/C+lan/C+lan.h
@@ -1,0 +1,36 @@
+#pragma once
+/**
+* @file		C+lan.h
+* @brief	C+lanのヘッダーファイルをまとめたファイル
+* @author	Kojima, Kosei
+* @date		2024.1.30
+*/
+// ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
+// 　	 コンポーネント系		　　//
+// ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
+#include "BoxCollider.h"	// ボックスの当たり判定
+#include "Camera.h"			// カメラ
+#include "Material.h"		// マテリアル
+#include "Shader.h"			// シェーダー
+#include "Text.h"			// テキスト
+#include "Transform.h"		// トランスフォーム
+	
+
+// ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
+// 　		  入力系			　　//
+// ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
+#include "InputPartsName.h"	// 入力系名称
+#include "KeyInput.h"		// キー入力
+#include "MouseInput.h"		// マウス入力
+#include "ScreenInput.h"	// 画面入力
+
+
+// ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
+// 　		　  その他 　		　　//
+// ＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝ //
+#include "CalculationHit.h"	// 当たり判定の計算一覧
+#include "Color.h"			// 色
+#include "SceneManager.h"	// シーンマネージャー
+#include "Time.h"			// 時間
+#include "Vector2.h"		// 2次元ベクトル
+#include "Vector3.h"		// 3次元ベクトル

--- a/C+lan/C+lan/C+lan.vcxproj
+++ b/C+lan/C+lan/C+lan.vcxproj
@@ -76,7 +76,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <IncludePath>C:\directxtk\include;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\directxtk\lib\x64\Debug;$(LibraryPath)</LibraryPath>
+    <LibraryPath>C:\directxtk\lib\x64\Release;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -194,6 +194,7 @@
   <ItemGroup>
     <ClInclude Include="Application.h" />
     <ClInclude Include="BoxCollider.h" />
+    <ClInclude Include="C+lan.h" />
     <ClInclude Include="CalculationHit.h" />
     <ClInclude Include="Camera.h" />
     <ClInclude Include="Color.h" />

--- a/C+lan/C+lan/C+lan.vcxproj.filters
+++ b/C+lan/C+lan/C+lan.vcxproj.filters
@@ -392,5 +392,8 @@
     <ClInclude Include="ShortCutKey.h">
       <Filter>ヘッダー ファイル\C+lan\PrivateSystem</Filter>
     </ClInclude>
+    <ClInclude Include="C+lan.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/C+lan/C+lan/Server.h
+++ b/C+lan/C+lan/Server.h
@@ -119,7 +119,7 @@ namespace Ctlan
 
 				/// <summary>
 				///	他ユーザーにメッセージを送る	</summary>
-				void SendMessageOtherUser();
+				void SendMessageOtherUser(MessageData& sendMessage);
 
 			public:
 				// ----- functions / 関数 ----- //

--- a/C+lan/C+lan/SystemGameObjectManager.cpp
+++ b/C+lan/C+lan/SystemGameObjectManager.cpp
@@ -86,6 +86,9 @@ void Ctlan::PrivateSystem::SystemManager::SystemGameObjectManager::SetObjectName
 
 void Ctlan::PrivateSystem::SystemManager::SystemGameObjectManager::DeleteObjectNameData(const char* name)
 {
+	// リストに要素が入っていない？
+	if (m_objectNameList.empty())	return;	//処理を終了
+
 	// 引数の値と同じオブジェクト名の情報を削除
 	m_objectNameList.erase(
 		std::find_if(

--- a/C+lan/C+lan/TextRenderer.cpp
+++ b/C+lan/C+lan/TextRenderer.cpp
@@ -1,11 +1,10 @@
 #include "SystemSceneManager.h"
 #include "SystemNetWorkManager.h"
-#include "SpectatorCamera.h"
-
-#include "TextRenderer.h"
 #include "SystemTextRendererManager.h"
-#include "Transform.h"
+#include "SpectatorCamera.h"
 #include <WICTextureLoader.h>
+
+#include "C+lan.h"
 
 
 void TextRenderer::Init()


### PR DESCRIPTION
【内容】
サーバーを開いたユーザーのメッセージがログイン中のユーザー全員に送信されていなかった
＞m_sendAddressに設定されたアドレスにしか送信していなかった
【解決方法】
オーナーのみ、ログインしているユーザー数分メッセージを送る記述を追加