### PR TITLE
Fix: release時、ウィンドウのみ生成されるように変更

### DIFF
--- a/C+lan/C+lan/C+lan.vcxproj
+++ b/C+lan/C+lan/C+lan.vcxproj
@@ -144,7 +144,7 @@ xcopy /y /e /i "$(ProjectDir)Assets\Textures" "$(TargetDir)Assets\"</Command>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
+      <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/C+lan/C+lan/Main.cpp
+++ b/C+lan/C+lan/Main.cpp
@@ -4,6 +4,7 @@
 #include "Application.h"
 #include <time.h>
 
+#if _DEBUG
 int main()
 {
     srand((unsigned int)time(NULL));    // 乱数用
@@ -14,3 +15,15 @@ int main()
 
     return 0;
 }
+#else
+int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
+{
+    srand((unsigned int)time(NULL));    // 乱数用
+
+    //**  アプリケーション実行  **//
+    Ctlan::PrivateSystem::Application app;
+    app.Run();
+
+    return 0;
+}
+#endif


### PR DESCRIPTION
【内容】
releaseビルド時はコンソール画面は不要なので、ウィンドウアプリケーションに変更
それに伴いエントリポイントのためにmain.cppにwinmain関数を追加