### PR TITLE
Fix: シーンを開く際、存在しないシーン名が入力されるとシーンがリセットされる不具合を修正

### DIFF
--- a/C+lan/C+lan/Main.cpp
+++ b/C+lan/C+lan/Main.cpp
@@ -5,6 +5,7 @@
 #include <time.h>
 
 #if _DEBUG
+// Debugビルド時のエントリポイント
 int main()
 {
     srand((unsigned int)time(NULL));    // 乱数用
@@ -16,6 +17,7 @@ int main()
     return 0;
 }
 #else
+// Releaseビルド時のエントリポイント
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
 {
     srand((unsigned int)time(NULL));    // 乱数用

--- a/C+lan/C+lan/SystemSceneManager.cpp
+++ b/C+lan/C+lan/SystemSceneManager.cpp
@@ -180,8 +180,6 @@ Ctlan::PrivateSystem::SceneBase* Ctlan::PrivateSystem::SystemManager::SystemScen
 {
 	// ベースシーンの生成
 	SceneBase* loadScene = new SceneBase(loadSceneName);
-	// ロードしたシーンを代入
-	m_loadedScene = loadScene;
 
 	// シーンファイル名を取得
 	char sceneFileName[100] = {"Assets/Scenes/"};
@@ -195,6 +193,13 @@ Ctlan::PrivateSystem::SceneBase* Ctlan::PrivateSystem::SystemManager::SystemScen
 	// 開くことができた？
 	if (file)
 	{
+		// 別シーンがロードされている？
+		if(m_loadedScene)
+			// 現在シーンの終了処理
+			m_loadedScene->Uninit();
+		// ロードしたシーンを代入
+		m_loadedScene = loadScene;
+
 		// ===== ロード処理 ===== //
 		int layerNo = 0;
 		char objectType[100] = { 0 };
@@ -382,12 +387,9 @@ void Ctlan::PrivateSystem::SystemManager::SystemSceneManager::LoadScene()
 			ZeroMemory(loadSceneName, sizeof(loadSceneName));
 			return;
 		}
-		// シーンがロードされていない
+		// 該当シーンはロードされていないorシーンが存在しない
 		else
 		{
-			// 現在シーンの終了処理
-			m_loadedScene->Uninit();
-
 			// ロードするシーンが存在しない？
 			if (LoadSceneData(loadSceneName) == nullptr)
 			{


### PR DESCRIPTION
【原因】
シーンファイルを開いて、入力されたシーンが存在するか確認する前に
現在シーンの終了処理を実行していた

＞シーンファイルが正しく開くことができた際に終了処理を実行するように変更